### PR TITLE
Added ViewModel to hold in-memory state; support rotate; liveData to publish state, re-arrangement

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -46,7 +46,7 @@ android {
         targetCompatibility 1.8
     }
 
-    kotlinOptions { jvmTarget = "1.8"}
+    kotlinOptions { jvmTarget = "1.8" }
 }
 
 dependencies {
@@ -61,15 +61,14 @@ dependencies {
 
             // Hilt
             "com.google.dagger:hilt-android:$hilt_version",
-            'androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha01',
+            "androidx.hilt:hilt-lifecycle-viewmodel:1.0.0-alpha01",
 
             // Lifecycle components
             "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version",
             "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version",
-            "androidx.lifecycle:lifecycle-viewmodel-savedstate:$lifecycle_version",
             // Navigation
             "androidx.navigation:navigation-fragment-ktx:$nav_version",
-            "androidx.navigation:navigation-ui-ktx:$nav_version",
+            "androidx.navigation:navigation-ui-ktx:$nav_version"
     )
 
     // Room
@@ -77,7 +76,7 @@ dependencies {
             "androidx.lifecycle:lifecycle-compiler:$lifecycle_version",
             'androidx.room:room-compiler:2.2.5',
             "com.google.dagger:hilt-android-compiler:$hilt_version",
-            'androidx.hilt:hilt-compiler:1.0.0-alpha01'
+            "androidx.hilt:hilt-compiler:1.0.0-alpha01"
 
     )
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,9 +27,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name=".ui.MainActivity"
-            android:screenOrientation="portrait"
-            tools:ignore="LockedOrientationActivity">
+            android:name=".ui.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />

--- a/app/src/main/java/com/example/android/hilt/contentprovider/LogsContentProvider.kt
+++ b/app/src/main/java/com/example/android/hilt/contentprovider/LogsContentProvider.kt
@@ -23,9 +23,8 @@ import android.content.Context
 import android.content.UriMatcher
 import android.database.Cursor
 import android.net.Uri
-import com.example.android.hilt.data.LogDao
+import com.example.android.hilt.datasource.logs.LogDao
 import dagger.hilt.EntryPoint
-import dagger.hilt.EntryPoints
 import dagger.hilt.InstallIn
 import dagger.hilt.android.EntryPointAccessors
 import dagger.hilt.android.components.ApplicationComponent

--- a/app/src/main/java/com/example/android/hilt/datasource/AppDatabase.kt
+++ b/app/src/main/java/com/example/android/hilt/datasource/AppDatabase.kt
@@ -14,14 +14,17 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.data
+package com.example.android.hilt.datasource
 
-// Common interface for Logger data sources.
-interface LoggerDataSource {
+import androidx.room.Database
+import androidx.room.RoomDatabase
+import com.example.android.hilt.datasource.logs.LogDao
+import com.example.android.hilt.datasource.model.Log
 
-    fun addLog(msg: String)
-
-    fun getAllLogs(callback: (List<Log>) -> Unit)
-
-    fun removeLogs()
+/**
+ * SQLite Database for storing the logs.
+ */
+@Database(entities = [Log::class], version = 1, exportSchema = false)
+abstract class AppDatabase : RoomDatabase() {
+    abstract fun logDao(): LogDao
 }

--- a/app/src/main/java/com/example/android/hilt/datasource/logs/LogDao.kt
+++ b/app/src/main/java/com/example/android/hilt/datasource/logs/LogDao.kt
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.data
+package com.example.android.hilt.datasource.logs
 
 import android.database.Cursor
 import androidx.room.Dao
 import androidx.room.Insert
 import androidx.room.Query
+import com.example.android.hilt.datasource.model.Log
 
 /**
  * Data access object to query the database.

--- a/app/src/main/java/com/example/android/hilt/datasource/logs/LoggerDataSource.kt
+++ b/app/src/main/java/com/example/android/hilt/datasource/logs/LoggerDataSource.kt
@@ -14,24 +14,16 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.data
+package com.example.android.hilt.datasource.logs
 
-import java.util.LinkedList
-import javax.inject.Inject
+import com.example.android.hilt.datasource.model.Log
 
-class LoggerInMemoryDataSource @Inject constructor() : LoggerDataSource {
+// Common interface for Logger data sources.
+interface LoggerDataSource {
 
-    private val logs = LinkedList<Log>()
+    fun addLog(msg: String)
 
-    override fun addLog(msg: String) {
-        logs.addFirst(Log(msg, System.currentTimeMillis()))
-    }
+    fun getAllLogs(callback: (List<Log>) -> Unit)
 
-    override fun getAllLogs(callback: (List<Log>) -> Unit) {
-        callback(logs)
-    }
-
-    override fun removeLogs() {
-        logs.clear()
-    }
+    fun removeLogs()
 }

--- a/app/src/main/java/com/example/android/hilt/datasource/logs/LoggerInMemoryDataSource.kt
+++ b/app/src/main/java/com/example/android/hilt/datasource/logs/LoggerInMemoryDataSource.kt
@@ -14,15 +14,28 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.data
+package com.example.android.hilt.datasource.logs
 
-import androidx.room.Database
-import androidx.room.RoomDatabase
+import com.example.android.hilt.datasource.model.Log
+import java.util.*
+import javax.inject.Inject
 
-/**
- * SQLite Database for storing the logs.
- */
-@Database(entities = arrayOf(Log::class), version = 1, exportSchema = false)
-abstract class AppDatabase : RoomDatabase() {
-    abstract fun logDao(): LogDao
+class LoggerInMemoryDataSource @Inject constructor() :
+    LoggerDataSource {
+
+    private val logs = LinkedList<Log>()
+
+    override fun addLog(msg: String) {
+        logs.addFirst(
+            Log(msg, System.currentTimeMillis())
+        )
+    }
+
+    override fun getAllLogs(callback: (List<Log>) -> Unit) {
+        callback(logs)
+    }
+
+    override fun removeLogs() {
+        logs.clear()
+    }
 }

--- a/app/src/main/java/com/example/android/hilt/datasource/logs/LoggerLocalDataSource.kt
+++ b/app/src/main/java/com/example/android/hilt/datasource/logs/LoggerLocalDataSource.kt
@@ -14,12 +14,11 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.data
+package com.example.android.hilt.datasource.logs
 
 import android.os.Handler
-import android.os.Looper
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
+import com.example.android.hilt.datasource.model.Log
+import java.util.concurrent.*
 import javax.inject.Inject
 
 /**

--- a/app/src/main/java/com/example/android/hilt/datasource/model/Log.kt
+++ b/app/src/main/java/com/example/android/hilt/datasource/model/Log.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.data
+package com.example.android.hilt.datasource.model
 
 import androidx.room.Entity
 import androidx.room.PrimaryKey

--- a/app/src/main/java/com/example/android/hilt/di/DatabaseModule.kt
+++ b/app/src/main/java/com/example/android/hilt/di/DatabaseModule.kt
@@ -18,8 +18,8 @@ package com.example.android.hilt.di
 
 import android.content.Context
 import androidx.room.Room
-import com.example.android.hilt.data.AppDatabase
-import com.example.android.hilt.data.LogDao
+import com.example.android.hilt.datasource.AppDatabase
+import com.example.android.hilt.datasource.logs.LogDao
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn

--- a/app/src/main/java/com/example/android/hilt/di/LoggingModule.kt
+++ b/app/src/main/java/com/example/android/hilt/di/LoggingModule.kt
@@ -16,14 +16,14 @@
 
 package com.example.android.hilt.di
 
-import com.example.android.hilt.data.*
+import com.example.android.hilt.datasource.logs.*
 import com.example.android.hilt.di.qualifier.DatabaseLogger
 import com.example.android.hilt.di.qualifier.InMemoryLogger
 import dagger.Binds
 import dagger.Module
 import dagger.hilt.InstallIn
-import dagger.hilt.android.components.ActivityComponent
-import dagger.hilt.android.components.ApplicationComponent
+import dagger.hilt.android.components.*
+import dagger.hilt.android.scopes.ActivityRetainedScoped
 import dagger.hilt.android.scopes.ActivityScoped
 import javax.inject.Singleton
 
@@ -37,12 +37,12 @@ abstract class LoggingDatabaseModule {
     abstract fun bindDatabaseLogger(impl: LoggerLocalDataSource): LoggerDataSource
 }
 
-@InstallIn(ActivityComponent::class)
+@InstallIn(ActivityRetainedComponent::class)
 @Module
 abstract class LoggingInMemoryModule {
 
     @InMemoryLogger
-    @ActivityScoped
+    @ActivityRetainedScoped
     @Binds
     abstract fun bindInMemoryLogger(impl: LoggerInMemoryDataSource): LoggerDataSource
 }

--- a/app/src/main/java/com/example/android/hilt/ui/ButtonsFragment.kt
+++ b/app/src/main/java/com/example/android/hilt/ui/ButtonsFragment.kt
@@ -21,7 +21,7 @@ import android.view.*
 import androidx.fragment.app.Fragment
 import com.example.android.hilt.R
 import com.example.android.hilt.analytics.AnalyticsService
-import com.example.android.hilt.data.LoggerDataSource
+import com.example.android.hilt.datasource.logs.LoggerDataSource
 import com.example.android.hilt.di.qualifier.DatabaseLogger
 import com.example.android.hilt.di.qualifier.InMemoryLogger
 import com.example.android.hilt.navigator.AppNavigator

--- a/app/src/main/java/com/example/android/hilt/ui/logs/LogsFragment.kt
+++ b/app/src/main/java/com/example/android/hilt/ui/logs/LogsFragment.kt
@@ -95,7 +95,7 @@ class LogsFragment : Fragment() {
     }
 
     private fun analyticsTrack() {
-        //Notice the AnalyticsServiceImpl instances, they are created/destroyed per fragment lifecycle
+        // Notice the AnalyticsServiceImpl instances, they are created/destroyed per fragment lifecycle
         analyticsService.track(this::class.simpleName.toString())
     }
 }

--- a/app/src/main/java/com/example/android/hilt/ui/logs/LogsFragment.kt
+++ b/app/src/main/java/com/example/android/hilt/ui/logs/LogsFragment.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.example.android.hilt.ui
+package com.example.android.hilt.ui.logs
 
 import android.annotation.SuppressLint
 import android.os.Bundle
@@ -23,12 +23,14 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.Observer
 import androidx.navigation.fragment.navArgs
 import androidx.recyclerview.widget.RecyclerView
 import com.example.android.hilt.R
 import com.example.android.hilt.analytics.AnalyticsService
-import com.example.android.hilt.data.Log
-import com.example.android.hilt.data.LoggerDataSource
+import com.example.android.hilt.datasource.model.Log
+import com.example.android.hilt.datasource.logs.LoggerDataSource
 import com.example.android.hilt.di.qualifier.DatabaseLogger
 import com.example.android.hilt.di.qualifier.InMemoryLogger
 import com.example.android.hilt.navigator.LogsScreen
@@ -53,6 +55,8 @@ class LogsFragment : Fragment() {
 
     @Inject lateinit var analyticsService: AnalyticsService
 
+    private val logsViewModel: LogsViewModelImpl by viewModels()
+
     private val args: LogsFragmentArgs by navArgs()
 
     override fun onCreateView(
@@ -66,8 +70,14 @@ class LogsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         rvLogs.setHasFixedSize(true)
 
+        logsViewModel
+            .logs
+            .observe(viewLifecycleOwner, Observer { logs ->
+                rvLogs.adapter = LogsViewAdapter(logs, dateFormatter)
+            })
+
         when (args.logType) {
-            LogsScreen.ALL_IN_MEM_LOGS -> getLogFrom(logger)
+            LogsScreen.ALL_IN_MEM_LOGS -> logsViewModel.getInMemLogs()
             LogsScreen.ALL_IN_DB_LOGS -> getLogFrom(dbLogger)
         }
 
@@ -85,7 +95,7 @@ class LogsFragment : Fragment() {
     }
 
     private fun analyticsTrack() {
-        android.util.Log.d("AnalyticsHilt", "Notice the AnalyticsServiceImpl instances, they are created/destroyed per fragment lifecycle")
+        //Notice the AnalyticsServiceImpl instances, they are created/destroyed per fragment lifecycle
         analyticsService.track(this::class.simpleName.toString())
     }
 }

--- a/app/src/main/java/com/example/android/hilt/ui/logs/LogsViewModel.kt
+++ b/app/src/main/java/com/example/android/hilt/ui/logs/LogsViewModel.kt
@@ -1,0 +1,25 @@
+package com.example.android.hilt.ui.logs
+
+import androidx.hilt.lifecycle.ViewModelInject
+import androidx.lifecycle.*
+import com.example.android.hilt.datasource.model.Log
+import com.example.android.hilt.ui.logs.usecase.GetInMemLogsUseCase
+
+class LogsViewModelImpl @ViewModelInject constructor(
+    private val getInMemLogsUseCase: GetInMemLogsUseCase
+) : ViewModel() {
+
+    private val _logs = MutableLiveData<List<Log>>()
+
+    val logs: LiveData<List<Log>>
+        get() = _logs
+
+    fun getInMemLogs() {
+        // Rotate the screen, you will observe that the ViewModel & UseCase are retained the same instances.
+        android.util.Log.d("ViewModelHilt", "ViewModel: $this useCase: $getInMemLogsUseCase")
+        getInMemLogsUseCase.execute {
+            _logs.postValue(it)
+        }
+    }
+
+}

--- a/app/src/main/java/com/example/android/hilt/ui/logs/usecase/GetInMemLogsUseCase.kt
+++ b/app/src/main/java/com/example/android/hilt/ui/logs/usecase/GetInMemLogsUseCase.kt
@@ -11,8 +11,8 @@ class GetInMemLogsUseCase @Inject constructor(
     fun execute(callback: (List<Log>) -> Unit) {
         // Rotate the screen, you will see loggerDataSource will be persisted because they are scoped to
         // ActivityRetainedScoped,
-        // Also note: if you go back and forth, the same DataSource is still survived, because the VM is
-        // still tied to the Activity's Scope.
+        // Also note: if you go back and forth, the same DataSource is still survived, because it is
+        // tied to RetainedActivityScoped (ViewModel).
         android.util.Log.d("UseCaseHilt", "DataSource: $loggerDataSource")
         return loggerDataSource.getAllLogs(callback)
     }

--- a/app/src/main/java/com/example/android/hilt/ui/logs/usecase/GetInMemLogsUseCase.kt
+++ b/app/src/main/java/com/example/android/hilt/ui/logs/usecase/GetInMemLogsUseCase.kt
@@ -1,0 +1,19 @@
+package com.example.android.hilt.ui.logs.usecase
+
+import com.example.android.hilt.datasource.logs.LoggerDataSource
+import com.example.android.hilt.datasource.model.Log
+import com.example.android.hilt.di.qualifier.InMemoryLogger
+import javax.inject.Inject
+
+class GetInMemLogsUseCase @Inject constructor(
+    @InMemoryLogger val loggerDataSource: LoggerDataSource
+) {
+    fun execute(callback: (List<Log>) -> Unit) {
+        // Rotate the screen, you will see loggerDataSource will be persisted because they are scoped to
+        // ActivityRetainedScoped,
+        // Also note: if you go back and forth, the same DataSource is still survived, because the VM is
+        // still tied to the Activity's Scope.
+        android.util.Log.d("UseCaseHilt", "DataSource: $loggerDataSource")
+        return loggerDataSource.getAllLogs(callback)
+    }
+}

--- a/app/src/main/res/layout/fragment_logs.xml
+++ b/app/src/main/res/layout/fragment_logs.xml
@@ -19,7 +19,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".ui.LogsFragment">
+    tools:context=".ui.logs.LogsFragment">
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/rvLogs"

--- a/app/src/main/res/navigation/main_navigation.xml
+++ b/app/src/main/res/navigation/main_navigation.xml
@@ -16,7 +16,7 @@
 
     <fragment
         android:id="@+id/logsFragment"
-        android:name="com.example.android.hilt.ui.LogsFragment"
+        android:name="com.example.android.hilt.ui.logs.LogsFragment"
         android:label="fragment_logs"
         tools:layout="@layout/fragment_logs">
 


### PR DESCRIPTION
1. Added ViewModel showcase: 1 blocker is that I can't make it Bind via an interface of ViewModel because there seems to be a constraint that @ViewModelInject must be derived from an @AndroidEntryPoint directly, a.k.a from Fragment, you can use `by lazy viewModels()` to instantiate this ViewModel that had @ViewModelInject in the constructor, and only from that.
2. Added UseCase, hopefully, this brings the business logic separation better for unit testing.
3. Added multiple Logs to explain the use case for demos purpose.
4. Made use of the @RetainedActivityComponent/Scope, see LoggingModule > LoggingInMemoryModule > @InMemoryLogger for further details
5. Support orientation change and persisting data, from 1. and 4.